### PR TITLE
feat: render video shot list + json format in afp_get_article

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build
 .claude
 .cortex
 .agents
+docs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "afpnews-mcp-server",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "",
   "main": "src/index.ts",
   "type": "module",
@@ -28,12 +28,12 @@
     "jose": "^6.2.2"
   },
   "peerDependencies": {
-    "afpnews-api": "^2.4.0",
+    "afpnews-api": "^2.5.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^25.5.2",
-    "afpnews-api": "^2.4.1",
+    "afpnews-api": "^2.5.0",
     "zod": "^4.3.6"
   }
 }

--- a/src/__tests__/create-server.test.ts
+++ b/src/__tests__/create-server.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it, mock } from 'bun:test';
+import * as actualApi from 'afpnews-api';
 
 describe('createServer', () => {
   it('authenticates with provided credentials', async () => {
     const authenticateMock = mock().mockResolvedValue(undefined);
 
     mock.module('afpnews-api', () => ({
+      ...actualApi,
       ApiCore: class {
         token?: unknown;
         config?: unknown;
@@ -23,6 +25,7 @@ describe('createServer', () => {
   it('passes baseUrl to ApiCore when provided', async () => {
     let capturedConfig: unknown;
     mock.module('afpnews-api', () => ({
+      ...actualApi,
       ApiCore: class {
         token?: unknown;
         constructor(config?: unknown) { capturedConfig = config; }
@@ -40,6 +43,7 @@ describe('createServer', () => {
   it('does not set baseUrl on ApiCore when omitted', async () => {
     let capturedConfig: unknown;
     mock.module('afpnews-api', () => ({
+      ...actualApi,
       ApiCore: class {
         token?: unknown;
         constructor(config?: unknown) { capturedConfig = config; }
@@ -56,6 +60,7 @@ describe('createServer', () => {
 
   it('throws on missing credentials', async () => {
     mock.module('afpnews-api', () => ({
+      ...actualApi,
       ApiCore: class {
         token?: unknown;
         constructor() {}

--- a/src/__tests__/fixtures.ts
+++ b/src/__tests__/fixtures.ts
@@ -27,6 +27,20 @@ export const FIXTURE_DOC_MINIMAL: AFPDocument = {
   news: ['Only one paragraph.'],
 };
 
+export const FIXTURE_VIDEO_DOC: AFPDocument = {
+  uno: 'AFP-TEST-VID-001',
+  headline: 'Test Video Headline',
+  published: '2026-02-14T10:30:00Z',
+  lang: 'fr',
+  genre: 'STOCKSHOTS',
+  class: 'video',
+  news: [
+    '1. 00:00-00:12 Vue aérienne de la ville',
+    '2. 00:12-00:30 SOUNDBITE 1 - Jean Dupont, témoin',
+    '"Tout a commencé très vite"',
+  ],
+};
+
 export function makeDocs(count: number): AFPDocument[] {
   return Array.from({ length: count }, (_, i) => ({
     uno: `AFP-TEST-${String(i + 1).padStart(3, '0')}`,

--- a/src/__tests__/format.test.ts
+++ b/src/__tests__/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
-import { formatDocument, MARKDOWN_API_FIELDS } from '../utils/format.js';
-import { FIXTURE_DOC, FIXTURE_DOC_MINIMAL } from './fixtures.js';
+import { formatDocument, formatFullArticle, formatShotList, MARKDOWN_API_FIELDS } from '../utils/format.js';
+import { FIXTURE_DOC, FIXTURE_DOC_MINIMAL, FIXTURE_VIDEO_DOC } from './fixtures.js';
 
 describe('formatDocument', () => {
   it('returns { type: "text", text: string }', () => {
@@ -62,5 +62,38 @@ describe('MARKDOWN_API_FIELDS', () => {
   it('does not contain published or afpshortid (derivable from UNO)', () => {
     expect(MARKDOWN_API_FIELDS).not.toContain('published');
     expect(MARKDOWN_API_FIELDS).not.toContain('afpshortid');
+  });
+});
+
+describe('formatShotList', () => {
+  it('renders a timecoded shot list for a video document', () => {
+    const out = formatShotList(FIXTURE_VIDEO_DOC);
+    expect(out).toContain('## Shot list');
+    expect(out).toContain('1. [00:00-00:12] Vue aérienne de la ville');
+    expect(out).toContain('2. [00:12-00:30] Jean Dupont, témoin');
+    expect(out).toContain('   "Tout a commencé très vite"');
+  });
+
+  it('returns null for non-video documents', () => {
+    expect(formatShotList(FIXTURE_DOC)).toBeNull();
+  });
+
+  it('returns null for a video whose news has no parseable shot', () => {
+    expect(formatShotList({ class: 'video', news: ['no timecode here'] })).toBeNull();
+  });
+});
+
+describe('formatFullArticle', () => {
+  it('uses the shot list as body for a video document', () => {
+    const result = formatFullArticle(FIXTURE_VIDEO_DOC);
+    expect(result.text).toContain('## Shot list');
+    expect(result.text).toContain('[00:00-00:12] Vue aérienne de la ville');
+    expect(result.text).toContain('**Class:** video');
+  });
+
+  it('keeps the plain text body for non-video documents', () => {
+    const result = formatFullArticle(FIXTURE_DOC);
+    expect(result.text).not.toContain('## Shot list');
+    expect(result.text).toContain('First paragraph of the article.');
   });
 });

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -6,7 +6,7 @@ import { registerTools } from '../tools/index.js';
 import { registerResources } from '../resources/index.js';
 import { registerPrompts } from '../prompts/index.js';
 import type { ServerContext } from '../mcp-server.js';
-import { FIXTURE_DOC, makeDocs } from './fixtures.js';
+import { FIXTURE_DOC, FIXTURE_VIDEO_DOC, makeDocs } from './fixtures.js';
 
 function createMockApicore() {
   return {
@@ -254,6 +254,24 @@ describe('MCP integration', () => {
       const text = getText(result);
       expect(text).not.toContain('**Status:**');
       expect(text).not.toContain('**Country:**');
+    });
+
+    it('renders a timecoded shot list body for video documents', async () => {
+      apicore.get.mockResolvedValueOnce(FIXTURE_VIDEO_DOC);
+      const result = await client.callTool({ name: 'afp_get_article', arguments: { uno: 'AFP-TEST-VID-001' } });
+      const text = getText(result);
+      expect(text).toContain('## Shot list');
+      expect(text).toContain('1. [00:00-00:12] Vue aérienne de la ville');
+      expect(text).toContain('"Tout a commencé très vite"');
+    });
+
+    it('returns the raw document as json when format=json', async () => {
+      apicore.get.mockResolvedValueOnce(FIXTURE_DOC);
+      const result = await client.callTool({ name: 'afp_get_article', arguments: { uno: 'AFP-TEST-001', format: 'json' } });
+      const text = getText(result);
+      const parsed = JSON.parse(text);
+      expect(parsed.uno).toBe('AFP-TEST-001');
+      expect(parsed.news).toEqual(FIXTURE_DOC.news);
     });
 
     it('returns isError on API failure', async () => {

--- a/src/tools/get-article.ts
+++ b/src/tools/get-article.ts
@@ -1,10 +1,14 @@
 import { z } from 'zod';
 import type { ApiCore } from 'afpnews-api';
-import { formatFullArticle, toolError } from '../utils/format.js';
+import { formatFullArticle, textContent, toolError } from '../utils/format.js';
 import { formatErrorMessage, UNO_FORMAT_NOTE } from './shared.js';
 
 const inputSchema = z.object({
   uno: z.string().describe('The unique UNO identifier of the article'),
+  format: z
+    .enum(['markdown', 'json'])
+    .optional()
+    .describe('Output format: markdown (default, rendered article/shot list) or json (raw document, parse it yourself).'),
 });
 
 type GetArticleInput = z.infer<typeof inputSchema>;
@@ -37,11 +41,15 @@ Returns:
   - Full article body (all paragraphs, no truncation)
 
 Example:
-  { uno: "newsml.afp.com.20260222T090659Z.doc-98hu39e" }`,
+  { uno: "newsml.afp.com.20260222T090659Z.doc-98hu39e" }
+  { uno: "newsml.afp.com.20260222T090659Z.doc-98hu39e", format: "json" }`,
   inputSchema,
-  handler: async (apicore: Pick<ApiCore, 'get'>, { uno }: GetArticleInput) => {
+  handler: async (apicore: Pick<ApiCore, 'get'>, { uno, format = 'markdown' }: GetArticleInput) => {
     try {
       const doc = await apicore.get(uno);
+      if (format === 'json') {
+        return { content: [textContent(JSON.stringify(doc, null, 2))] };
+      }
       return { content: [formatFullArticle(doc)] };
     } catch (error) {
       return toolError(formatErrorMessage(`fetching article "${uno}"`, error, 'Verify the UNO identifier is correct.'));

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,5 +1,30 @@
+import { parseShotList } from 'afpnews-api';
 import type { AFPDocument, TextContent } from './types.js';
 import { EXCERPT_PARAGRAPH_COUNT, CHARACTER_LIMIT } from './types.js';
+
+const VIDEO_CLASSES = new Set(['video', 'videography']);
+
+/**
+ * Render a video shot list (timecodes + descriptions + soundbite quotes) from
+ * the raw `news` lines. Returns `null` when the document is not a video or when
+ * no shot could be parsed, so callers can fall back to the plain text body.
+ */
+export function formatShotList(doc: unknown): string | null {
+  const d = doc as AFPDocument;
+  if (!VIDEO_CLASSES.has(String(d['class']))) return null;
+
+  const news = Array.isArray(d.news) ? d.news : [];
+  const shots = parseShotList(news.join('\n'));
+  if (shots.length === 0) return null;
+
+  const lines = shots.map((shot) => {
+    const head = `${shot.numero}. [${shot.start}-${shot.end}] ${shot.description}`.trimEnd();
+    const quotes = shot.citations.map((c) => `   "${c.text}"`);
+    return [head, ...quotes].join('\n');
+  });
+
+  return `## Shot list\n\n${lines.join('\n')}`;
+}
 
 export function truncationHint(remaining?: number): string {
   const suffix = remaining != null && remaining > 0
@@ -163,7 +188,7 @@ export function formatFullArticle(doc: unknown): TextContent {
   if (flags) lines.push(flags);
 
   const meta = lines.join('\n');
-  const body = (Array.isArray(d.news) ? d.news : []).join('\n\n');
+  const body = formatShotList(d) ?? (Array.isArray(d.news) ? d.news : []).join('\n\n');
 
   return textContent(`## ${d.headline}\n\n${meta}\n\n---\n\n${body}`);
 }


### PR DESCRIPTION
## Contexte

`afp_get_article` déversait la dopesheet brute des vidéos comme corps d'article (`news.join('\n\n')`), et n'offrait pas de sortie structurée. Cette PR corrige le rendu vidéo et ajoute un format `json`.

## Changements

- **Fix vidéo** : `formatFullArticle` rend désormais une **shot list timecodée** pour `class: video/videography` via `parseShotList` (afpnews-api), avec **fallback** sur le texte brut si rien ne parse → aucune perte de contenu.
- **`format: 'markdown' | 'json'`** sur `afp_get_article` : `json` renvoie le document brut (à parser côté consommateur), `markdown` reste le défaut.
- Peer dep `afpnews-api` → `^2.5.0` (fournit `parseShotList`).
- Mock `afpnews-api` complété dans les tests (spread du vrai module).
- Fixture vidéo + tests (`formatShotList`, `formatFullArticle`, handler json).

115 tests ✅, `tsc` clean. `2.0.2` → `2.1.0`.

## Dépendance

Requiert la publication d'`afpnews-api@2.5.0` (PR julesbonnard/afpnews-api#91).

🤖 Generated with [Claude Code](https://claude.com/claude-code)