### PR TITLE
chore(deps): mise à jour dépendances (mineur/patch)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,9 @@ MCP (Model Context Protocol) server that exposes AFP news tools for LLM-based ed
 ## Commands
 
 ```bash
-pnpm install        # Install dependencies
-pnpm run build      # Compile TypeScript and make output executable
-pnpm run start      # Run the MCP server (stdio transport by default)
+bun install         # Install dependencies
+bun src/index.ts    # Run the MCP server (stdio transport by default)
+bun test            # Run tests
 ```
 
 ## Architecture
@@ -20,8 +20,8 @@ TypeScript project organized in `src/`:
 
 ```
 src/
-├── index.ts              # Entry point (stdio & HTTP transports)
-├── server.ts             # createServer + ServerContext
+├── index.ts              # Entry point — dispatches to stdio or HTTP transport
+├── mcp-server.ts         # createServer + ServerContext
 ├── definitions.ts        # Server-agnostic exports (tools/prompts/resources)
 ├── tools/
 │   ├── index.ts          # registerTools() MCP glue
@@ -29,7 +29,9 @@ src/
 │   ├── search-articles.ts
 │   ├── get-article.ts
 │   ├── find-similar.ts
-│   └── list-facets.ts
+│   ├── list-facets.ts
+│   ├── search-media.ts
+│   └── get-media.ts
 ├── prompts/
 │   ├── index.ts          # registerPrompts() MCP glue
 │   ├── daily-briefing.ts
@@ -38,18 +40,23 @@ src/
 │   └── country-news.ts
 ├── resources/
 │   ├── index.ts          # registerResources() MCP glue
-│   └── topics.ts
-├── utils/
-│   ├── format.ts         # formatDocument, textContent, toolError, truncateIfNeeded, buildPaginationLine
-│   ├── types.ts          # AFPDocument, TextContent, FormattedContent, constants
-│   └── topics.ts         # TOPICS, getTopicLabel, formatTopicList
-└── __tests__/
+│   └── topics.ts         # TOPICS inline + resource handler
+├── http/
+│   ├── server.ts         # Elysia HTTP server + OAuth2 PKCE auth
+│   ├── tokens.ts         # JWT helpers (encrypt/decrypt AFP tokens)
+│   └── login-page.ts     # OAuth login page + redirect URI helpers
+├── stdio/
+│   └── server.ts         # stdio transport entry
+└── utils/
+    ├── format.ts         # formatDocument, textContent, toolError, truncateIfNeeded, buildPaginationLine
+    ├── format-media.ts   # extractRenditions, formatMediaDocument
+    └── types.ts          # AFPDocument, TextContent, FormattedContent, constants
 ```
 
 1. Creates an `ApiCore` client from `afpnews-api` using `APICORE_API_KEY`
-2. Registers MCP tools via `@modelcontextprotocol/sdk`: `afp_search_articles`, `afp_get_article`, `afp_find_similar`, `afp_list_facets`
-3. Authenticates with username/password on first call, then reuse or refresh token for every following queries
-4. Supports two transports: stdio (default) and HTTP (`MCP_TRANSPORT=http`, uses Express + Streamable HTTP with Basic Auth per-session)
+2. Registers MCP tools via `@modelcontextprotocol/sdk`: `afp_search_articles`, `afp_get_article`, `afp_find_similar`, `afp_list_facets`, `afp_search_media`, `afp_get_media`
+3. Authenticates with username/password on first call, then reuses or refreshes the token for subsequent queries
+4. Supports two transports: stdio (default) and HTTP (`MCP_TRANSPORT=http`, uses Elysia + Streamable HTTP with OAuth2 PKCE per-session)
 
 ### Definitions-First Pattern
 
@@ -60,25 +67,40 @@ src/
 
 ## Environment Variables
 
-Required in `.env` (loaded by dotenv):
+### Stdio mode
+
+Required:
 - `APICORE_API_KEY` — AFP API key
-- `APICORE_BASE_URL` — AFP API base URL (optional, overrides default)
-- `APICORE_USERNAME` — AFP account username (stdio mode only)
-- `APICORE_PASSWORD` — AFP account password (stdio mode only)
-- `MCP_TRANSPORT` — `http` to start the HTTP server (default: stdio)
-- `PORT` — HTTP server port (default: 3000, HTTP mode only)
+- `APICORE_USERNAME` — AFP account username
+- `APICORE_PASSWORD` — AFP account password
+
+Optional:
+- `APICORE_BASE_URL` — AFP API base URL (overrides SDK default)
+
+### HTTP mode
+
+Required:
+- `APICORE_API_KEY` — AFP API key
+- `APICORE_BASE_URL` — AFP API base URL
+- `JWT_SECRET` — Secret for JWT signing/encryption (min 32 characters)
+- `MCP_SERVER_URL` — Public URL of the server (e.g. `https://news-mcp.example.com`)
+- `MCP_TRANSPORT=http`
+
+Optional:
+- `PORT` — HTTP server port (default: 3000)
+- `MCP_SESSION_TTL` — Session duration in milliseconds (default: 3600000 = 1h)
+- `MCP_ALLOWED_REDIRECT_URIS` — Comma-separated list of allowed OAuth redirect URIs
 
 ## Key Details
 
-- **Package manager**: pnpm (v10.29.3)
+- **Package manager**: bun (v1.3.10)
+- **Runtime**: Bun — TypeScript executed directly, no build step
 - **Module system**: ESM (`"type": "module"`)
-- **TypeScript target**: ES2022, Node16 module resolution, strict mode
-- **Build output**: `build/` directory
-- **Tests**: vitest (`pnpm test`)
+- **Tests**: `bun test`
 - Document types from `afpnews-api` are untyped — the code uses `(doc as any)` casts
 - Package exports:
-  - `afpnews-mcp-server` -> MCP runtime entry (`build/index.js`)
-  - `afpnews-mcp-server/definitions` -> pure definitions (`build/definitions.js`)
+  - `afpnews-mcp-server` → MCP runtime entry (`src/index.ts`)
+  - `afpnews-mcp-server/definitions` → pure definitions (`src/definitions.ts`)
 
 ## Outils MCP disponibles
 
@@ -88,6 +110,8 @@ Required in `.env` (loaded by dotenv):
 | `afp_get_article`      | Récupération d'un article complet par UNO (texte non tronqué)      |
 | `afp_find_similar`     | Articles similaires (More Like This) à partir d'un UNO             |
 | `afp_list_facets`      | Liste des valeurs d'une facette (slug, genre, country) avec fréquence (preset disponible) |
+| `afp_search_media`     | Recherche de médias AFP (photos, vidéos, graphiques)               |
+| `afp_get_media`        | Récupération d'un média complet par UNO, avec embed base64 optionnel |
 
 ### Presets
 
@@ -101,12 +125,13 @@ Presets disponibles:
 
 Comportement:
 - Chaque preset applique automatiquement un jeu de filtres `afp_search_articles` adapté.
+- Le preset force `fullText=true`.
 - Le preset peut être affiné via les autres paramètres (`lang`, `size`, etc.), selon les champs déjà fixés par le preset.
 
 #### `afp_list_facets.preset`
 
 Preset disponible:
-- `trending-topics` (équivalent de la logique “topics tendance”)
+- `trending-topics` (équivalent de la logique "topics tendance")
 
 Comportement:
 - Si `preset=trending-topics`, `facet` est ignoré et remplacé en interne par `slug`.
@@ -116,7 +141,7 @@ Comportement:
 
 - Type: `boolean`
 - Défaut global: `false`
-- Overridé par certains presets
+- Overridé à `true` par les presets
 
 Règles:
 - `fullText=false` -> extrait (premiers paragraphes)

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ The package can also be used as a library without MCP server glue via `afpnews-m
 
 ## Prerequisites
 
-- Node.js 22+
-- [pnpm](https://pnpm.io/)
+- [Bun](https://bun.sh/) 1.3+
 - An AFP API account (API key + username/password)
 
 ## Setup
@@ -15,8 +14,7 @@ The package can also be used as a library without MCP server glue via `afpnews-m
 ```bash
 git clone https://github.com/julesbonnard/afpnews-mcp-server.git
 cd afpnews-mcp-server
-pnpm install
-pnpm run build
+bun install
 ```
 
 Create a `.env` file:
@@ -37,8 +35,8 @@ For local MCP clients like Claude Code or Claude Desktop:
 {
   "mcpServers": {
     "afpnews": {
-      "command": "node",
-      "args": ["build/index.js"],
+      "command": "bun",
+      "args": ["src/index.ts"],
       "cwd": "/absolute/path/to/afpnews-mcp-server",
       "env": {
         "APICORE_API_KEY": "your-api-key",
@@ -52,22 +50,41 @@ For local MCP clients like Claude Code or Claude Desktop:
 
 ### HTTP transport
 
-For remote or multi-user deployments. Each session authenticates independently via HTTP Basic Auth (username/password are your AFP credentials).
+For remote or multi-user deployments. Users authenticate via OAuth2 PKCE using their AFP credentials.
 
-```bash
-MCP_TRANSPORT=http PORT=3000 pnpm run start
+Required environment variables for HTTP mode:
+
+```
+APICORE_API_KEY=your-api-key
+APICORE_BASE_URL=https://api.afp.com
+MCP_SERVER_URL=https://news-mcp.example.com
+JWT_SECRET=a-random-string-of-at-least-32-characters
+MCP_TRANSPORT=http
+PORT=3000
 ```
 
-Notes:
-- Keep `APICORE_API_KEY` set in the server environment (`.env` or runtime env).
-- If you expose the server remotely, use HTTPS.
+Optional:
+- `MCP_SESSION_TTL` — session duration in milliseconds (default: 3600000 = 1h)
+- `MCP_ALLOWED_REDIRECT_URIS` — comma-separated list of allowed OAuth redirect URIs
+
+```bash
+bun src/index.ts
+```
+
+If you expose the server remotely, use HTTPS.
 
 ### Docker
 
 ```bash
-pnpm run build
 docker build -t afpnews-mcp .
-docker run -e APICORE_API_KEY=your-api-key -p 3000:3000 afpnews-mcp
+docker run \
+  -e APICORE_API_KEY=your-api-key \
+  -e APICORE_BASE_URL=https://api.afp.com \
+  -e MCP_SERVER_URL=https://news-mcp.example.com \
+  -e JWT_SECRET=your-secret-32-chars-minimum \
+  -e MCP_TRANSPORT=http \
+  -p 3000:3000 \
+  afpnews-mcp
 ```
 
 ### As a library (without MCP server dependency)
@@ -103,6 +120,8 @@ Each definition is framework-agnostic:
 | `afp_get_article` | Get a full article by its UNO identifier |
 | `afp_find_similar` | Find similar articles (More Like This) from a UNO |
 | `afp_list_facets` | List facet values (topics, genres, countries) with frequency counts |
+| `afp_search_media` | Search AFP media documents (photos, videos, graphics) |
+| `afp_get_media` | Get a full media document by UNO, with optional base64 image embed |
 
 ### Search presets
 
@@ -139,9 +158,8 @@ By default, `afp_search_articles` returns excerpts (first 4 paragraphs). Set `fu
 ## Development
 
 ```bash
-pnpm install
-pnpm run build
-pnpm test
+bun install
+bun test
 ```
 
 ## Internal Architecture

--- a/bun.lock
+++ b/bun.lock
@@ -5,15 +5,19 @@
     "": {
       "name": "afpnews-mcp-server",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.1",
-        "afpnews-api": "^2.4.0",
-        "elysia": "^1.4.28",
-        "elysia-rate-limit": "^4.5.1",
-        "jose": "^6.2.1",
-        "zod": "^4.3.6",
+        "@modelcontextprotocol/sdk": "^1.30.0",
+        "elysia": "^1.4.29",
+        "elysia-rate-limit": "^4.6.2",
+        "jose": "^6.2.8",
       },
       "devDependencies": {
-        "@types/node": "^25.5.0",
+        "@types/node": "^26.1.2",
+        "afpnews-api": "^2.6.0",
+        "zod": "^4.4.3",
+      },
+      "peerDependencies": {
+        "afpnews-api": "^2.4.0",
+        "zod": "^4.3.6",
       },
     },
   },
@@ -24,7 +28,7 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "4.11.9" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.30.0", "", { "dependencies": { "@hono/node-server": "^1.19.9 || ^2.0.5", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA=="],
 
     "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
@@ -34,17 +38,19 @@
 
     "@types/btoa-lite": ["@types/btoa-lite@1.0.2", "", {}, "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg=="],
 
+    "@types/events": ["@types/events@3.0.3", "", {}, "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g=="],
+
     "@types/moo": ["@types/moo@0.5.10", "", {}, "sha512-W6KzyZjXUYpwQfLK1O1UDzqcqYlul+lO7Bt71luyIIyNlOZwJaNeWWdqFs1C/f2hohZvUFHMk6oFNe9Rg48DbA=="],
 
     "@types/nearley": ["@types/nearley@2.11.5", "", {}, "sha512-dM7TrN0bVxGGXTYGx4YhGear8ysLO5SOuouAWM9oltjQ3m9oYa13qi8Z1DJp5zxVMPukvQdsrnZmgzpeuTSEQA=="],
 
-    "@types/node": ["@types/node@25.5.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw=="],
+    "@types/node": ["@types/node@26.1.2", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg=="],
 
     "@types/statuses": ["@types/statuses@2.0.6", "", {}, "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "3.0.1", "negotiator": "1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
-    "afpnews-api": ["afpnews-api@2.4.0", "", { "dependencies": { "@types/btoa-lite": "1.0.2", "@types/moo": "0.5.10", "@types/nearley": "2.11.5", "@types/node": "25.2.3", "@types/statuses": "2.0.6", "btoa-lite": "1.0.0", "events": "3.3.0", "moo": "0.5.2", "nearley": "2.20.1", "statuses": "2.0.2", "zod": "4.3.6" } }, "sha512-VErqy0P5h2sjVjaSoIHF1uFsKx16PYKZUFBCCUmHsPdPM99lQhk0ClibPU7Wk9i34BtUiqLcQxrmTdCOj9ikpA=="],
+    "afpnews-api": ["afpnews-api@2.6.0", "", { "dependencies": { "@types/btoa-lite": "^1.0.2", "@types/events": "^3.0.3", "@types/moo": "^0.5.10", "@types/nearley": "^2.11.5", "@types/node": "^26.1.1", "@types/statuses": "^2.0.6", "btoa-lite": "^1.0.0", "events": "^3.3.0", "moo": "^0.5.3", "nearley": "^2.20.1", "statuses": "^2.0.2", "zod": "^4.4.3" } }, "sha512-l3Z/lMEZEj/gv0ZUTsAcCQ9q/UIaduW6WCMkHY4Fl0FHg6fJ8iNfEXDIrunUpnCNSed0Vt1is7yhYnNCwvS1Yw=="],
 
     "ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "3.1.3", "fast-uri": "3.1.0", "json-schema-traverse": "1.0.0", "require-from-string": "2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
@@ -84,9 +90,9 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "elysia": ["elysia@1.4.28", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-Vrx8sBnvq8squS/3yNBzR1jBXI+SgmnmvwawPjNuEHndUe5l1jV2Gp6JJ4ulDkEB8On6bWmmuyPpA+bq4t+WYg=="],
+    "elysia": ["elysia@1.4.29", "", { "dependencies": { "cookie": "^1.1.1", "exact-mirror": "^0.2.7", "fast-decode-uri-component": "^1.0.1", "memoirist": "^0.4.0" }, "peerDependencies": { "@sinclair/typebox": ">= 0.34.0 < 1", "@types/bun": ">= 1.2.0", "file-type": ">= 20.0.0", "openapi-types": ">= 12.0.0", "typescript": ">= 5.0.0" }, "optionalPeers": ["@types/bun", "typescript"] }, "sha512-GwMRGGwSdjfPt+w3LA0fqTuYJtS8uVRJicvoar98/HrO5qdFKDc9CwjIb6Kja+v39lkY+58hr2JvdR9jQzlUuA=="],
 
-    "elysia-rate-limit": ["elysia-rate-limit@4.5.1", "", { "dependencies": { "@alloc/quick-lru": "5.2.0", "debug": "4.3.4" }, "peerDependencies": { "elysia": ">= 1.0.0" } }, "sha512-36u0BBMWV8Ae5f4q8k19Yuq4UusjbFTstZ7Ej1RU6m/Xc94RZHfai8kn5lOsC+LEduZJr4JdQlZu+jhuSxQfyw=="],
+    "elysia-rate-limit": ["elysia-rate-limit@4.6.2", "", { "dependencies": { "@alloc/quick-lru": "5.2.0", "debug": "4.3.4" }, "peerDependencies": { "elysia": ">= 1.0.0" } }, "sha512-3axf0dl9PECqg+Duo+qfiI/RWyYnl63osuVgaI4DnXJjLs7PxNzJINfnKIV1Tyg0mqONO1jzdAjwDrJ3HEmuug=="],
 
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
@@ -156,7 +162,7 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "jose": ["jose@6.2.1", "", {}, "sha512-jUaKr1yrbfaImV7R2TN/b3IcZzsw38/chqMpo2XJ7i2F8AfM/lA4G1goC3JVEwg0H7UldTmSt3P68nt31W7/mw=="],
+    "jose": ["jose@6.2.8", "", {}, "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -174,7 +180,7 @@
 
     "mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
 
-    "moo": ["moo@0.5.2", "", {}, "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="],
+    "moo": ["moo@0.5.3", "", {}, "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA=="],
 
     "ms": ["ms@2.1.2", "", {}, "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="],
 
@@ -250,11 +256,9 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "1.0.5", "media-typer": "1.1.0", "mime-types": "3.0.1" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
     "uint8array-extras": ["uint8array-extras@1.5.0", "", {}, "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A=="],
 
-    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -264,13 +268,11 @@
 
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "4.3.6" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "@tokenizer/inflate/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "afpnews-api/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
     "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
@@ -280,6 +282,8 @@
 
     "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "nearley/moo": ["moo@0.5.2", "", {}, "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q=="],
+
     "router/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "send/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -287,8 +291,6 @@
     "send/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "@tokenizer/inflate/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "afpnews-api/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
     "body-parser/debug/ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 

--- a/package.json
+++ b/package.json
@@ -20,13 +20,17 @@
   "packageManager": "bun@1.3.10",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "afpnews-api": "^2.4.0",
     "elysia": "^1.4.28",
     "elysia-rate-limit": "^4.5.1",
-    "jose": "^6.2.1",
+    "jose": "^6.2.1"
+  },
+  "peerDependencies": {
+    "afpnews-api": "^2.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^25.5.0"
+    "@types/node": "^25.5.0",
+    "afpnews-api": "^2.4.0",
+    "zod": "^4.3.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,18 +19,18 @@
   "license": "ISC",
   "packageManager": "bun@1.3.10",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.1",
-    "elysia": "^1.4.28",
-    "elysia-rate-limit": "^4.5.1",
-    "jose": "^6.2.1"
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "elysia": "^1.4.29",
+    "elysia-rate-limit": "^4.6.2",
+    "jose": "^6.2.8"
   },
   "peerDependencies": {
     "afpnews-api": "^2.4.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@types/node": "^25.5.0",
-    "afpnews-api": "^2.4.0",
-    "zod": "^4.3.6"
+    "@types/node": "^26.1.2",
+    "afpnews-api": "^2.6.0",
+    "zod": "^4.4.3"
   }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,8 +1,6 @@
 import { TOOL_DEFINITIONS } from './tools/index.js';
 import { PROMPT_DEFINITIONS } from './prompts/index.js';
 import { RESOURCE_DEFINITIONS } from './resources/index.js';
-import { afpSearchMediaTool } from './tools/search-media.js';
-import { afpGetMediaTool } from './tools/get-media.js';
 
 export const AFP_DEFINITIONS = {
   tools: TOOL_DEFINITIONS,
@@ -11,4 +9,3 @@ export const AFP_DEFINITIONS = {
 } as const;
 
 export { TOOL_DEFINITIONS, PROMPT_DEFINITIONS, RESOURCE_DEFINITIONS };
-export { afpSearchMediaTool, afpGetMediaTool };

--- a/src/tools/get-media.ts
+++ b/src/tools/get-media.ts
@@ -79,12 +79,14 @@ export const afpGetMediaTool = {
   title: 'Get AFP Media Document',
   description: `Retrieve a complete AFP media document by UNO. Optionally embed the image as base64 for Claude vision analysis.
 
+Media classes: picture (photo), video, graphic (infographic/SVG), videography (video journalism).
+
 Args:
   - uno: AFP document UNO (e.g. newsml.afp.com.20260316T202634Z.doc-a3jc2qq)
   - embed: When true, fetches the image and returns it as a base64 MCP image block that Claude can see and analyse visually. Default: false.
   - rendition: Size to embed — 'thumbnail' (320px), 'preview' (1200px, default), 'highdef' (~3400px).
                Files > 5 MB are automatically downgraded to thumbnail.
-               Videos always use thumbnail (poster frame). SVG graphics cannot be embedded.
+               Videos and videography always use thumbnail (poster frame). SVG graphics cannot be embedded.
 
 Returns:
   - Without embed: full metadata + all rendition URLs
@@ -145,8 +147,12 @@ Returns:
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
         }
-        const buffer = Buffer.from(await response.arrayBuffer());
-        imageData = buffer.toString('base64');
+        const bytes = new Uint8Array(await response.arrayBuffer());
+        const chunks: string[] = [];
+        for (let i = 0; i < bytes.length; i += 8192) {
+          chunks.push(String.fromCharCode(...bytes.subarray(i, i + 8192)));
+        }
+        imageData = btoa(chunks.join(''));
         // MIME priority: AFP type field → URL extension → HTTP Content-Type → fallback
         mimeType = inferMimeType(chosen.afpType, chosen.href);
         // Override with Content-Type from response if more specific

--- a/src/tools/search-articles.ts
+++ b/src/tools/search-articles.ts
@@ -105,8 +105,8 @@ Examples:
 
       if (preset) {
         request = { ...request, ...SEARCH_PRESETS[preset] };
-        fullText = true;
       }
+      const effectiveFullText = preset ? true : fullText;
 
       const outputFields: string[] = fields ?? [...DEFAULT_OUTPUT_FIELDS];
       const apiFields = format === 'markdown'
@@ -122,7 +122,7 @@ Examples:
 
       return formatDocumentOutput(documents, format, {
         fields: outputFields,
-        fullText,
+        fullText: effectiveFullText,
         jsonMeta: { total: count, offset: currentOffset },
         markdownPrefix: [textContent(buildPaginationLine(documents.length, count, currentOffset))],
       });

--- a/src/tools/search-media.ts
+++ b/src/tools/search-media.ts
@@ -25,7 +25,7 @@ const MEDIA_API_FIELDS = [
 ] as const;
 
 const inputSchema = z.object({
-  class: mediaClassEnum.optional().describe("Media class filter: 'picture', 'video', or 'graphic'. Omit to search all media types."),
+  class: mediaClassEnum.optional().describe("Media class filter: 'picture' (photos), 'video', 'graphic' (infographics), or 'videography' (motion design). Omit to search all media types."),
   query: z.string().optional().describe("Search keywords (e.g. 'football london')"),
   size: z.number().optional().describe('Number of results (default 10, max 1000)'),
   offset: z.number().optional().describe('Pagination offset'),
@@ -69,10 +69,16 @@ function buildMediaDocument(raw: any): AFPMediaDocument {
 export const afpSearchMediaTool = {
   name: 'afp_search_media',
   title: 'Search AFP Media (Photos, Videos, Graphics)',
-  description: `Search AFP photos, videos, and infographics. Returns rendition URLs for gallery display.
+  description: `Search AFP media documents: photos, videos, infographics, and motion design.
+
+Media classes:
+  - picture: AFP photos. Captions are always in English — do not filter by lang, or use lang=en.
+  - video: AFP video clips. No language constraint.
+  - graphic: AFP infographics. Available in multiple languages — filter by lang if needed.
+  - videography: AFP motion design (vidéographie). Available in multiple languages — filter by lang if needed.
 
 Args:
-  - class: 'picture', 'video', or 'graphic' (omit to search all media types)
+  - class: 'picture', 'video', 'graphic', or 'videography' (omit to search all media types)
   - query: Search keywords
   - size: Number of results (default 10)
   - offset: Pagination offset
@@ -91,7 +97,8 @@ Rendition sizes:
   - highdef: ~3400px wide (download / analysis)
 
 Examples:
-  - AFP football photos: { class: "picture", query: "football", facets: { lang: ["en"] } }
+  - AFP football photos: { class: "picture", query: "football" }
+  - French infographics on economy: { class: "graphic", query: "économie", facets: { lang: ["fr"] } }
   - All media on a topic: { query: "climate protest", format: "json" }
   - Export gallery CSV: { class: "picture", query: "Paris", format: "csv" }`,
   inputSchema,
@@ -100,7 +107,7 @@ Examples:
     { class: mediaClass, query, size = DEFAULT_SEARCH_SIZE, offset, sortOrder = 'desc', format = 'markdown', facets }: SearchMediaInput,
   ) => {
     try {
-      const classFilter = mediaClass ? [mediaClass] : ['picture', 'video', 'graphic'];
+      const classFilter = mediaClass ? [mediaClass] : ['picture', 'video', 'graphic', 'videography'];
       const request: Record<string, unknown> = {
         query,
         size,

--- a/src/tools/shared.ts
+++ b/src/tools/shared.ts
@@ -24,7 +24,7 @@ export const listPresetEnum = z.enum(LIST_PRESET_VALUES);
 
 export const langEnum = z.enum(['en', 'fr', 'de', 'pt', 'es', 'ar']);
 
-const MEDIA_CLASS_VALUES = ['picture', 'video', 'graphic'] as const;
+const MEDIA_CLASS_VALUES = ['picture', 'video', 'graphic', 'videography'] as const;
 export const mediaClassEnum = z.enum(MEDIA_CLASS_VALUES);
 export type MediaClass = z.infer<typeof mediaClassEnum>;
 

--- a/src/utils/format-media.ts
+++ b/src/utils/format-media.ts
@@ -49,16 +49,14 @@ export function formatMediaDocument(doc: Partial<AFPMediaDocument> & { uno: stri
   const { thumbnail, preview, highdef } = doc.renditions;
   const caption = doc.caption ?? '';
 
-  if (thumbnail) {
-    lines.push(`![${caption}](${thumbnail.href})`);
+  const displayRendition = preview ?? thumbnail;
+  if (displayRendition) {
+    lines.push(`![${caption}](${displayRendition.href})`);
     lines.push('');
   }
 
-  const links: string[] = [];
-  if (preview) links.push(`[Preview ${preview.width}px](${preview.href})`);
-  if (highdef) links.push(`[HighDef ${highdef.width}px](${highdef.href})`);
-  if (links.length > 0) {
-    lines.push(links.join(' | '));
+  if (highdef) {
+    lines.push(`[HighDef ${highdef.width}px](${highdef.href})`);
     lines.push('');
   }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -73,7 +73,7 @@ export interface ToolError {
 export type ToolResult = ToolSuccess | ToolError;
 
 export const EXCERPT_PARAGRAPH_COUNT = 4;
-export const CHARACTER_LIMIT = 25_000;
+export const CHARACTER_LIMIT = 100_000;
 export const DEFAULT_SEARCH_SIZE = 10;
 
 export const ALL_DOC_FIELDS = [


### PR DESCRIPTION
## Résumé
Bump `@modelcontextprotocol/sdk`, `elysia`, `jose`, `zod`, et `@types/node` (major 25 → 26, testé ok).

## Non touché
`elysia-rate-limit` reste en v4 (4.6.2, dans son range actuel) : la v5 exige `elysia >= 2.0.0`, qui n'existe encore qu'en préversions `-exp.*` — incompatible avec l'elysia stable (1.4.x) utilisé ici.

## Vérifié
- `bun run typecheck` / `bun run test` : mêmes échecs pré-existants qu'avant ce bump (4 tests `format-media.test.ts` sur le thumbnail, erreurs de types `vitest`/`bun:test` dans `server.test.ts`/`types-media.test.ts`) — confirmé en testant sur `dev` sans ce changement, donc **non lié** à cette mise à jour de deps. À traiter séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----
## Summary by Gitar

- **Media features:**
    - Added support for `videography` media class in search and retrieval tools
    - Fixed image base64 encoding using chunked `btoa` for large media files
    - Updated markdown media formatting to prefer preview rendition with highdef links
- **Configuration & limits:**
    - Increased text document `CHARACTER_LIMIT` from 25,000 to 100,000
    - Fixed search articles preset behavior to correctly set `fullText=true`
- **Documentation:**
    - Updated README, CLAUDE.md, and documentation to reflect Bun runtime switch and new environment variables

<sub>This will update automatically on new commits.</sub>