### PR TITLE
fix(tests): corrige les échecs pré-existants (typecheck + assertions obsolètes)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,14 +6,19 @@
       "name": "afpnews-mcp-server",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "afpnews-api": "^2.4.0",
         "elysia": "^1.4.28",
         "elysia-rate-limit": "^4.5.1",
         "jose": "^6.2.1",
-        "zod": "^4.3.6",
       },
       "devDependencies": {
+        "@types/bun": "^1.3.14",
         "@types/node": "^25.5.0",
+        "afpnews-api": "^2.4.0",
+        "zod": "^4.3.6",
+      },
+      "peerDependencies": {
+        "afpnews-api": "^2.4.0",
+        "zod": "^4.3.6",
       },
     },
   },
@@ -34,6 +39,8 @@
 
     "@types/btoa-lite": ["@types/btoa-lite@1.0.2", "", {}, "sha512-ZYbcE2x7yrvNFJiU7xJGrpF/ihpkM7zKgw8bha3LNJSesvTtUNxbpzaT7WXBIryf6jovisrxTBvymxMeLLj1Mg=="],
 
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "@types/moo": ["@types/moo@0.5.10", "", {}, "sha512-W6KzyZjXUYpwQfLK1O1UDzqcqYlul+lO7Bt71luyIIyNlOZwJaNeWWdqFs1C/f2hohZvUFHMk6oFNe9Rg48DbA=="],
 
     "@types/nearley": ["@types/nearley@2.11.5", "", {}, "sha512-dM7TrN0bVxGGXTYGx4YhGear8ysLO5SOuouAWM9oltjQ3m9oYa13qi8Z1DJp5zxVMPukvQdsrnZmgzpeuTSEQA=="],
@@ -53,6 +60,8 @@
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "3.1.2", "content-type": "1.0.5", "debug": "4.4.3", "http-errors": "2.0.1", "iconv-lite": "0.7.2", "on-finished": "2.4.1", "qs": "6.14.2", "raw-body": "3.0.2", "type-is": "2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
     "btoa-lite": ["btoa-lite@1.0.0", "", {}, "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.14",
     "@types/node": "^25.5.0",
     "afpnews-api": "^2.4.0",
     "zod": "^4.3.6"

--- a/src/__tests__/format-media.test.ts
+++ b/src/__tests__/format-media.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import { extractRenditions, formatMediaDocument, formatMediaDocumentsAsJson, formatMediaDocumentsAsCsv, MEDIA_RENDITION_ROLE_MAP } from '../utils/format-media.js';
 
 // Fixture bagItem reprenant la structure réelle AFP
@@ -109,14 +109,20 @@ describe('formatMediaDocument', () => {
     expect(t).toContain('GBR');
   });
 
-  it('includes inline thumbnail image', () => {
+  // La preview (meilleure qualité) est affichée inline à la place du thumbnail quand elle est disponible.
+  it('includes inline preview image (preferred over thumbnail)', () => {
     const t = formatMediaDocument(doc).text;
+    expect(t).toContain('![A footballer heads the ball.](https://example.com/prev.jpg)');
+  });
+
+  it('falls back to inline thumbnail image when no preview', () => {
+    const docNoPreview = { ...doc, renditions: { thumbnail: doc.renditions.thumbnail, highdef: doc.renditions.highdef } };
+    const t = formatMediaDocument(docNoPreview).text;
     expect(t).toContain('![A footballer heads the ball.](https://example.com/thumb.jpg)');
   });
 
-  it('includes preview and highdef links', () => {
+  it('includes highdef link', () => {
     const t = formatMediaDocument(doc).text;
-    expect(t).toContain('[Preview 1200px](https://example.com/prev.jpg)');
     expect(t).toContain('[HighDef 3429px](https://example.com/hd.jpg)');
   });
 

--- a/src/__tests__/get-media.test.ts
+++ b/src/__tests__/get-media.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import { inferMimeType, selectRenditionForEmbed } from '../tools/get-media.js';
 import type { MediaRenditions } from '../utils/types.js';
 

--- a/src/__tests__/server.test.ts
+++ b/src/__tests__/server.test.ts
@@ -16,8 +16,20 @@ function createMockApicore() {
   };
 }
 
-function getText(result: any, index = 0): string {
-  return (result.content[index] as { type: string; text: string }).text;
+// `client.callTool()` perd son typage précis (le SDK infère `content` en `{}`) dès que `client` est
+// déclaré séparément puis assigné dans `beforeEach` plutôt qu'initialisé inline — bug de résolution
+// générique de zod/v4 côté @modelcontextprotocol/sdk. Ce wrapper réaffirme un type correct une fois pour toutes.
+type ToolCallResult = { content: Array<{ type: string; text: string }>; isError?: boolean };
+
+async function callTool(
+  client: Client,
+  params: { name: string; arguments?: Record<string, unknown> }
+): Promise<ToolCallResult> {
+  return client.callTool(params) as unknown as ToolCallResult;
+}
+
+function getText(result: ToolCallResult, index = 0): string {
+  return result.content[index].text;
 }
 
 async function setupServer() {
@@ -50,7 +62,7 @@ describe('MCP integration', () => {
 
   describe('afp_search_articles tool', () => {
     it('returns pagination line and markdown with UNO and title', async () => {
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test' } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test' } });
       // 1 pagination line + 3 documents
       expect(result.content).toHaveLength(4);
       const pagination = result.content![0] as { type: string; text: string };
@@ -63,7 +75,7 @@ describe('MCP integration', () => {
 
     it('returns text message on empty results', async () => {
       apicore.search.mockResolvedValueOnce({ documents: [], count: 0 });
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'nothing' } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'nothing' } });
       expect(result.content).toHaveLength(1);
       const msg = result.content![0] as { type: string; text: string };
       expect(msg.text).toBe('No results found.');
@@ -71,7 +83,7 @@ describe('MCP integration', () => {
 
     it('returns excerpt by default (no fullText)', async () => {
       apicore.search.mockResolvedValueOnce({ documents: [FIXTURE_DOC], count: 1 });
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test' } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test' } });
       // pagination line + 1 document
       const msg = result.content![1] as { type: string; text: string };
       expect(msg.text).toContain('Fourth paragraph wraps up.');
@@ -80,14 +92,14 @@ describe('MCP integration', () => {
 
     it('returns full text when fullText=true', async () => {
       apicore.search.mockResolvedValueOnce({ documents: [FIXTURE_DOC], count: 1 });
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test', fullText: true } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test', fullText: true } });
       const msg = result.content![1] as { type: string; text: string };
       expect(msg.text).toContain('Fifth paragraph is extra content.');
     });
 
     it('preset a-la-une applies filters and defaults to full text', async () => {
       apicore.search.mockResolvedValueOnce({ documents: [FIXTURE_DOC], count: 1 });
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { preset: 'a-la-une' } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { preset: 'a-la-une' } });
       const msg = result.content![1] as { type: string; text: string };
       expect(msg.text).toContain('Fifth paragraph is extra content.');
 
@@ -100,7 +112,7 @@ describe('MCP integration', () => {
     });
 
     it('passes genre facet to API query', async () => {
-      await client.callTool({
+      await callTool(client, {
         name: 'afp_search_articles',
         arguments: { query: 'title:Trump', facets: { genre: 'Papier général' } },
       });
@@ -109,7 +121,7 @@ describe('MCP integration', () => {
     });
 
     it('passes additional facet filters to API query', async () => {
-      await client.callTool({
+      await callTool(client, {
         name: 'afp_search_articles',
         arguments: {
           query: 'climate',
@@ -125,7 +137,7 @@ describe('MCP integration', () => {
     });
 
     it('rejects unknown top-level facet filters', async () => {
-      const result = await client.callTool({
+      const result = await callTool(client, {
         name: 'afp_search_articles',
         arguments: {
           query: 'climate',
@@ -138,7 +150,7 @@ describe('MCP integration', () => {
 
     it('shows pagination info when there are more results', async () => {
       apicore.search.mockResolvedValueOnce({ documents: makeDocs(3), count: 10 });
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test' } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test' } });
       const pagination = result.content![0] as { type: string; text: string };
       expect(pagination.text).toContain('Showing 3 of 10 results');
       expect(pagination.text).toContain('offset=3');
@@ -146,14 +158,14 @@ describe('MCP integration', () => {
 
     it('returns isError on API failure', async () => {
       apicore.search.mockRejectedValueOnce(new Error('Network timeout'));
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test' } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test' } });
       expect(result.isError).toBe(true);
       const msg = result.content![0] as { type: string; text: string };
       expect(msg.text).toContain('Network timeout');
     });
 
     it('returns json with total, shown, offset and documents array', async () => {
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test', format: 'json' } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test', format: 'json' } });
       expect(result.content).toHaveLength(1);
       const parsed = JSON.parse(getText(result));
       expect(parsed.total).toBe(3);
@@ -166,13 +178,13 @@ describe('MCP integration', () => {
     });
 
     it('returns json with only requested fields', async () => {
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test', format: 'json', fields: ['uno', 'headline'] } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test', format: 'json', fields: ['uno', 'headline'] } });
       const parsed = JSON.parse(getText(result));
       expect(Object.keys(parsed.documents[0])).toEqual(['uno', 'headline']);
     });
 
     it('returns csv with header and data rows', async () => {
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test', format: 'csv' } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test', format: 'csv' } });
       expect(result.content).toHaveLength(1);
       const lines = getText(result).split('\n');
       expect(lines[0]).toBe('uno,headline,lang,genre');
@@ -180,7 +192,7 @@ describe('MCP integration', () => {
     });
 
     it('returns csv with custom fields', async () => {
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test', format: 'csv', fields: ['uno', 'headline'] } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test', format: 'csv', fields: ['uno', 'headline'] } });
       const lines = getText(result).split('\n');
       expect(lines[0]).toBe('uno,headline');
       expect(lines[1]).toContain('AFP-TEST-001');
@@ -188,25 +200,27 @@ describe('MCP integration', () => {
     });
 
     it('truncates json when exceeding character limit', async () => {
-      const largeDocs = makeDocs(400);
-      apicore.search.mockResolvedValueOnce({ documents: largeDocs, count: 400 });
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test', format: 'json' } });
+      // 1000 docs ~117k chars (fields uno/headline/lang/genre), au-delà de CHARACTER_LIMIT (100k).
+      const largeDocs = makeDocs(1000);
+      apicore.search.mockResolvedValueOnce({ documents: largeDocs, count: 1000 });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test', format: 'json' } });
       const parsed = JSON.parse(getText(result));
       expect(parsed.truncated).toBe(true);
-      expect(parsed.shown).toBeLessThan(400);
-      expect(parsed.total).toBe(400);
+      expect(parsed.shown).toBeLessThan(1000);
+      expect(parsed.total).toBe(1000);
       // Should have a truncation hint as second content block
       expect(result.content).toHaveLength(2);
       expect(getText(result, 1)).toContain('truncated');
     });
 
     it('truncates csv when exceeding character limit', async () => {
-      const largeDocs = makeDocs(800);
-      apicore.search.mockResolvedValueOnce({ documents: largeDocs, count: 800 });
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test', format: 'csv' } });
+      // 4000 docs ~138k chars (fields uno/headline/lang/genre), au-delà de CHARACTER_LIMIT (100k).
+      const largeDocs = makeDocs(4000);
+      apicore.search.mockResolvedValueOnce({ documents: largeDocs, count: 4000 });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test', format: 'csv' } });
       const lines = getText(result).split('\n');
-      // header + fewer than 800 data rows
-      expect(lines.length).toBeLessThan(801);
+      // header + fewer than 4000 data rows
+      expect(lines.length).toBeLessThan(4001);
       expect(lines.length).toBeGreaterThan(1);
       // Should have a truncation hint as second content block
       expect(result.content).toHaveLength(2);
@@ -214,7 +228,7 @@ describe('MCP integration', () => {
     });
 
     it('json shown field matches actual documents in output', async () => {
-      const result = await client.callTool({ name: 'afp_search_articles', arguments: { query: 'test', format: 'json' } });
+      const result = await callTool(client, { name: 'afp_search_articles', arguments: { query: 'test', format: 'json' } });
       const parsed = JSON.parse(getText(result));
       expect(parsed.shown).toBe(parsed.documents.length);
     });
@@ -223,7 +237,7 @@ describe('MCP integration', () => {
   describe('afp_get_article tool', () => {
     it('returns formatted full article with metadata rows and body', async () => {
       apicore.get.mockResolvedValueOnce(FIXTURE_DOC);
-      const result = await client.callTool({ name: 'afp_get_article', arguments: { uno: 'AFP-TEST-001' } });
+      const result = await callTool(client, { name: 'afp_get_article', arguments: { uno: 'AFP-TEST-001' } });
       expect(result.content).toHaveLength(1);
       const text = getText(result);
       expect(text).toContain('## Test Article Headline');
@@ -239,7 +253,7 @@ describe('MCP integration', () => {
 
     it('does not include missing optional fields', async () => {
       apicore.get.mockResolvedValueOnce({ uno: 'X', headline: 'H', lang: 'fr', genre: 'news', published: '2026-01-01T00:00:00Z', news: ['body'] });
-      const result = await client.callTool({ name: 'afp_get_article', arguments: { uno: 'X' } });
+      const result = await callTool(client, { name: 'afp_get_article', arguments: { uno: 'X' } });
       const text = getText(result);
       expect(text).not.toContain('**Status:**');
       expect(text).not.toContain('**Country:**');
@@ -247,7 +261,7 @@ describe('MCP integration', () => {
 
     it('returns isError on API failure', async () => {
       apicore.get.mockRejectedValueOnce(new Error('Not found'));
-      const result = await client.callTool({ name: 'afp_get_article', arguments: { uno: 'BAD-UNO' } });
+      const result = await callTool(client, { name: 'afp_get_article', arguments: { uno: 'BAD-UNO' } });
       expect(result.isError).toBe(true);
       const msg = result.content![0] as { type: string; text: string };
       expect(msg.text).toContain('BAD-UNO');
@@ -257,7 +271,7 @@ describe('MCP integration', () => {
 
   describe('afp_find_similar tool', () => {
     it('returns summary line and formatted similar documents', async () => {
-      const result = await client.callTool({ name: 'afp_find_similar', arguments: { uno: 'AFP-TEST-001', lang: 'fr' } });
+      const result = await callTool(client, { name: 'afp_find_similar', arguments: { uno: 'AFP-TEST-001', lang: 'fr' } });
       // 1 summary line + 2 documents
       expect(result.content).toHaveLength(3);
       const summary = result.content![0] as { type: string; text: string };
@@ -268,21 +282,21 @@ describe('MCP integration', () => {
 
     it('returns text message on empty results', async () => {
       apicore.mlt.mockResolvedValueOnce({ documents: [], count: 0 });
-      const result = await client.callTool({ name: 'afp_find_similar', arguments: { uno: 'AFP-TEST-001', lang: 'fr' } });
+      const result = await callTool(client, { name: 'afp_find_similar', arguments: { uno: 'AFP-TEST-001', lang: 'fr' } });
       const msg = result.content![0] as { type: string; text: string };
       expect(msg.text).toBe('No similar articles found.');
     });
 
     it('returns isError on API failure', async () => {
       apicore.mlt.mockRejectedValueOnce(new Error('Invalid UNO'));
-      const result = await client.callTool({ name: 'afp_find_similar', arguments: { uno: 'BAD', lang: 'fr' } });
+      const result = await callTool(client, { name: 'afp_find_similar', arguments: { uno: 'BAD', lang: 'fr' } });
       expect(result.isError).toBe(true);
       const msg = result.content![0] as { type: string; text: string };
       expect(msg.text).toContain('Invalid UNO');
     });
 
     it('returns json with total and documents array', async () => {
-      const result = await client.callTool({ name: 'afp_find_similar', arguments: { uno: 'AFP-TEST-001', lang: 'fr', format: 'json' } });
+      const result = await callTool(client, { name: 'afp_find_similar', arguments: { uno: 'AFP-TEST-001', lang: 'fr', format: 'json' } });
       expect(result.content).toHaveLength(1);
       const parsed = JSON.parse(getText(result));
       expect(parsed.total).toBe(2);
@@ -291,7 +305,7 @@ describe('MCP integration', () => {
     });
 
     it('returns csv with header and data rows', async () => {
-      const result = await client.callTool({ name: 'afp_find_similar', arguments: { uno: 'AFP-TEST-001', lang: 'fr', format: 'csv' } });
+      const result = await callTool(client, { name: 'afp_find_similar', arguments: { uno: 'AFP-TEST-001', lang: 'fr', format: 'csv' } });
       const lines = getText(result).split('\n');
       expect(lines[0]).toBe('uno,headline,lang,genre');
       expect(lines).toHaveLength(3); // header + 2 docs
@@ -300,7 +314,7 @@ describe('MCP integration', () => {
 
   describe('afp_list_facets tool', () => {
     it('returns markdown-formatted facet list', async () => {
-      const result = await client.callTool({ name: 'afp_list_facets', arguments: { facet: 'slug' } });
+      const result = await callTool(client, { name: 'afp_list_facets', arguments: { facet: 'slug' } });
       const msg = result.content![0] as { type: string; text: string };
       expect(msg.type).toBe('text');
       expect(msg.text).toContain('## Facet: slug');
@@ -309,14 +323,14 @@ describe('MCP integration', () => {
     });
 
     it('returns isError when facet is missing without preset', async () => {
-      const result = await client.callTool({ name: 'afp_list_facets', arguments: {} });
+      const result = await callTool(client, { name: 'afp_list_facets', arguments: {} });
       expect(result.isError).toBe(true);
       const msg = result.content![0] as { type: string; text: string };
       expect(msg.text).toContain('Missing required parameter: facet');
     });
 
     it('preset trending-topics applies list overrides', async () => {
-      const result = await client.callTool({ name: 'afp_list_facets', arguments: { preset: 'trending-topics' } });
+      const result = await callTool(client, { name: 'afp_list_facets', arguments: { preset: 'trending-topics' } });
       const msg = result.content![0] as { type: string; text: string };
       expect(msg.text).toContain('## Trending Topics');
       expect(msg.text).toContain('42 articles');
@@ -328,21 +342,21 @@ describe('MCP integration', () => {
 
     it('returns isError on API failure', async () => {
       apicore.list.mockRejectedValueOnce(new Error('Service unavailable'));
-      const result = await client.callTool({ name: 'afp_list_facets', arguments: { facet: 'slug' } });
+      const result = await callTool(client, { name: 'afp_list_facets', arguments: { facet: 'slug' } });
       expect(result.isError).toBe(true);
       const msg = result.content![0] as { type: string; text: string };
       expect(msg.text).toContain('Service unavailable');
     });
 
     it('returns json array of {name, count}', async () => {
-      const result = await client.callTool({ name: 'afp_list_facets', arguments: { facet: 'slug', format: 'json' } });
+      const result = await callTool(client, { name: 'afp_list_facets', arguments: { facet: 'slug', format: 'json' } });
       expect(result.content).toHaveLength(1);
       const parsed = JSON.parse(getText(result));
       expect(parsed).toEqual([{ name: 'economy', count: 42 }]);
     });
 
     it('returns csv with name,count rows', async () => {
-      const result = await client.callTool({ name: 'afp_list_facets', arguments: { facet: 'slug', format: 'csv' } });
+      const result = await callTool(client, { name: 'afp_list_facets', arguments: { facet: 'slug', format: 'csv' } });
       const text = getText(result);
       expect(text).toBe('name,count\neconomy,42');
     });
@@ -352,7 +366,7 @@ describe('MCP integration', () => {
     it('topics resource returns catalog', async () => {
       const result = await client.readResource({ uri: 'afp://topics' });
       expect(result.contents).toHaveLength(1);
-      const parsed = JSON.parse(result.contents[0].text as string);
+      const parsed = JSON.parse((result.contents[0] as { text: string }).text);
       expect(parsed).toHaveProperty('fr');
       expect(parsed).toHaveProperty('en');
     });

--- a/src/__tests__/types-media.test.ts
+++ b/src/__tests__/types-media.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'bun:test';
 import type { AFPMediaDocument, MediaRendition, MediaRenditions, ImageContent, AnyContent, ToolSuccess } from '../utils/types.js';
 
 describe('AFPMediaDocument type', () => {


### PR DESCRIPTION
Suite à #7 : les échecs de `bun run typecheck`/`bun run test` étaient pré-existants sur `dev`, non liés à la mise à jour de deps. Cette PR les corrige.

## Typecheck (`tsc --noEmit`)
- **`@types/bun` manquant** : ajouté en devDependency, corrige toutes les erreurs `TS2307: Cannot find module 'bun:test'`.
- **Imports `vitest` erronés** : `format-media.test.ts`, `get-media.test.ts`, `types-media.test.ts` importaient depuis `vitest` alors que le projet n'utilise que `bun:test`. `bun test` les exécutait quand même via son shim de compat vitest, mais `tsc` ne résolvait pas le module. Corrigé.
- **`server.test.ts` — bug de typage `@modelcontextprotocol/sdk`** : `client.callTool()` perd son typage précis (`content` devient `{}`) dès que `client` est déclaré séparément (`let client: Client`) puis assigné dans `beforeEach`, plutôt qu'initialisé inline. Reproduit en isolation — semble être un bug de résolution générique zod/v4 côté SDK (le `Result` inféré via `Infer<typeof ResultSchema>` se dégrade à travers ce pattern de réassignation). Contournement : un wrapper `callTool()` avec un type de retour explicite, qui réaffirme le type une fois pour toutes plutôt que de caster à chaque site d'appel.
- Un `.text` accédé avant cast sur une union `readResource` (`TS2339`).

## Tests (`bun test`)
- **`format-media.test.ts`** : deux assertions étaient désynchronisées d'un refactor antérieur ("vignette d'image") — la preview haute résolution est désormais affichée inline à la place du thumbnail quand elle est disponible, et le lien `[Preview ...]` séparé a été supprimé (redondant avec l'inline). Mis à jour + ajout d'un test de fallback vers thumbnail quand aucune preview n'existe.
- **`server.test.ts`** : les deux tests de troncature JSON/CSV généraient 400/800 documents factices, ce qui ne dépasse plus `CHARACTER_LIMIT` (100k caractères, augmenté depuis l'écriture des tests). Ajustés à 1000/4000 documents (calcul en commentaire).

## Vérifié
- `bun run typecheck` ✅ (0 erreur)
- `bun run test` ✅ 91 passed, 0 failed (+ 4 passed sur `create-server.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)